### PR TITLE
fix(debian.sh): change  linux-headers-"$(uname -r)" to  linux-headers…

### DIFF
--- a/src/debian.sh
+++ b/src/debian.sh
@@ -29,7 +29,7 @@ function debian() {
 
     echo -e "  |- Installing Nvidia drivers and related packages... ${RED}(Might be long)${RESET}"
     # Install the Nvidia drivers along with 32-bit libraries and Vulkan tools
-    apt install -y linux-headers-"$(uname -r)" build-essential dkms firmware-misc-nonfree nvidia-driver nvidia-driver-libs:i386 vulkan-tools nvidia-cuda-dev nvidia-cuda-toolkit libnvoptix1 > /dev/null 2>&1
+    apt install -y linux-headers-amd64 build-essential dkms firmware-misc-nonfree nvidia-driver nvidia-driver-libs:i386 vulkan-tools nvidia-cuda-dev nvidia-cuda-toolkit libnvoptix1 > /dev/null 2>&1
 
     echo "Nvidia drivers installed successfully."
 }


### PR DESCRIPTION
…-amd64

 linux-headers-"$(uname -r)" replaced my meta-package to avoid remagnent headers (marqued installed manually) while autoremove/autopurge